### PR TITLE
Remove Munki-related input variables from download/pkg recipes

### DIFF
--- a/bimcollab_zoom/BIMcollabZOOM.download.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.download.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>APPLICATIONS_PATH</key>
 		<string>/Applications</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>BIMcollabZoom</string>
 		<key>PKGPAYLOAD_DIR</key>

--- a/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>APPLICATIONS_PATH</key>
 		<string>/Applications</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>BIMcollabZoom</string>
 		<key>PKGPAYLOAD_DIR</key>


### PR DESCRIPTION
Neither of these recipes have a MunkiImporter process, so the Munki-related input variables serve no purpose and may cause confusion for admins who override the recipes.