### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/bimcollab_zoom/BIMcollabZOOM.download.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.download.recipe
@@ -19,7 +19,7 @@
 		<key>RELATIVE_APP_PATH</key>
 		<string>%APPLICATIONS_PATH%/BIMcollab ZOOM/BIMcollab ZOOM.app</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>0.2.9</string>
 	<key>Process</key>
 	<array>

--- a/bimcollab_zoom/BIMcollabZOOM.munki.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.munki.recipe
@@ -54,7 +54,7 @@ rm -rf "/Applications/BIMcollab ZOOM/"
 </string>
 		</dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>0.3.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.bimcollab_zoom</string>

--- a/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
@@ -19,7 +19,7 @@
 		<key>RELATIVE_APP_PATH</key>
 		<string>%APPLICATIONS_PATH%/BIMcollab ZOOM/BIMcollab ZOOM.app</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>0.3.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.bimcollab_zoom</string>

--- a/sipgate_softphone/sipgate-softphone.download.recipe
+++ b/sipgate_softphone/sipgate-softphone.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>sipgate-softphone</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>0.3.1</string>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.