### PR TITLE
Pragli renamed to Pesto

### DIFF
--- a/Pragli/Pragli.download.recipe
+++ b/Pragli/Pragli.download.recipe
@@ -48,7 +48,7 @@ Due to dynamic JavaScript encoding of the dmg path, URLTextSearcher cannot be us
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Pragli.app/Contents/Info.plist</string>
+				<string>%pathname%/Pesto (Pragli).app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Pragli/Pragli.download.recipe
+++ b/Pragli/Pragli.download.recipe
@@ -3,15 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)
+Due to dynamic JavaScript encoding of the dmg path, URLTextSearcher cannot be used without further custom processor. This recipe must be updated once the path changes again.</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Pragli.</string>
+	<string>Downloads the latest version of Pragli, now named Pesto.</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.download.Pragli</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>Pragli</string>
+		<string>Pesto (Pragli)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -23,7 +24,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://storage.googleapis.com/always-on-cdf01.appspot.com/dist/Pragli.dmg</string>
+				<string>https://storage.googleapis.com/always-on-cdf01.appspot.com/dist/Pesto%20(Pragli).dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Pragli/Pragli.download.recipe
+++ b/Pragli/Pragli.download.recipe
@@ -37,7 +37,7 @@ Due to dynamic JavaScript encoding of the dmg path, URLTextSearcher cannot be us
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Pragli.app</string>
+				<string>%pathname%/Pesto (Pragli).app</string>
 				<key>requirement</key>
 				<string>identifier "pragli.com" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y88U4QXK53</string>
 			</dict>

--- a/Pragli/Pragli.munki.recipe
+++ b/Pragli/Pragli.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Pragli has been renamed to "Pesto (Pragli)". To allow updates, the internal name remains "Pragli".</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Pragli and imports it into Munki.</string>
 	<key>Identifier</key>
@@ -27,7 +27,7 @@
             <key>category</key>
 	        <string>Social Media</string>
 			<key>display_name</key>
-			<string>Pragli</string>
+			<string>Pesto</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
Pragli is now called "Pragli (Pesto)" and will probably once again be changed to Pesto. Since the download URL is created dynamically by JavaScript code, URLTextSearcher does not work without a custom processor. The URL is again hard-coded into the download recipe.