### PR TITLE
Foxit Reader

### DIFF
--- a/Foxit/FoxitPDFReader.download.recipe
+++ b/Foxit/FoxitPDFReader.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Download recipe for the latest version of Foxit PDF Reader.</string>
 	<key>Identifier</key>
-	<string>com.github.wycomco.download.foxit-pdf-reader</string>
+	<string>com.github.wycomco.download.FoxitPDFReader</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
@@ -93,20 +93,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>info_path</key>
-				<string>%found_filename%/Contents/Info.plist</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>LSMinimumSystemVersion</key>
-					<string>minimum_os_version</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PlistReader</string>
 		</dict>
 	</array>
 </dict>

--- a/Foxit/FoxitPDFReader.download.recipe
+++ b/Foxit/FoxitPDFReader.download.recipe
@@ -94,6 +94,20 @@
 			<key>Processor</key>
 			<string>Versioner</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%found_filename%/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>LSMinimumSystemVersion</key>
+					<string>minimum_os_version</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Foxit/FoxitPDFReader.download.recipe
+++ b/Foxit/FoxitPDFReader.download.recipe
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Download recipe for the latest version of Foxit PDF Reader.</string>
+	<key>Identifier</key>
+	<string>com.github.wycomco.download.foxit-pdf-reader</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Foxit PDF Reader</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+				<key>url</key>
+				<string>https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&amp;platform=Mac-OS-X&amp;version=&amp;package_type=&amp;distID=</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Foxit Corporation (8GN47HTP75)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>flat_pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/*.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/%found_basename%/payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/payload/Applications/*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%found_filename%/Contents/Info.plist</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -14,6 +14,8 @@
 		<string>Foxit PDF Reader</string>
 		<key>pkginfo</key>
 		<dict>
+			<key>blocking_applications</key>
+			<array/>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>
@@ -34,6 +36,12 @@
 /usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" ReaderLite_UpdateMode -bool FALSE
 # Do not use splash screen
 /usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" Preferences.General.bShowStartPage -bool FALSE</string>
+<key>postuninstall_script</key>
+<string>#!/bin/sh
+/bin/launchctl unload /Library/LaunchDaemons/com.foxit.PDFReaderUpdateService.plist
+/bin/rm "/Library/Preferences/com.foxit-software.Foxit PDF Reader.plist"
+exit 0</string>
+<key>unattended_install</key>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -41,7 +41,6 @@
 /bin/launchctl unload /Library/LaunchDaemons/com.foxit.PDFReaderUpdateService.plist
 /bin/rm "/Library/Preferences/com.foxit-software.Foxit PDF Reader.plist"
 exit 0</string>
-<key>unattended_install</key>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Imports the latest version of Foxit PDF Reader into you Munki repository.</string>
+	<string>Imports the latest version of Foxit PDF Reader into your Munki repository. Auto updates and splash screen will be disabled.</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.FoxitPDFReader</string>
 	<key>Input</key>
@@ -28,6 +28,12 @@
 			<string>Foxit PDF Reader</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/sh
+# Disable automatic in-updates
+/usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" ReaderLite_UpdateMode -bool FALSE
+# Do not use splash screen
+/usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" Preferences.General.bShowStartPage -bool FALSE</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -36,7 +36,7 @@
 /usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" ReaderLite_UpdateMode -bool FALSE
 # Do not use splash screen
 /usr/bin/defaults write "/Library/Preferences/com.foxit-software.Foxit PDF Reader" Preferences.General.bShowStartPage -bool FALSE</string>
-<key>postuninstall_script</key>
+<key>preuninstall_script</key>
 <string>#!/bin/sh
 /bin/launchctl unload /Library/LaunchDaemons/com.foxit.PDFReaderUpdateService.plist
 /bin/rm "/Library/Preferences/com.foxit-software.Foxit PDF Reader.plist"

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Imports the latest version of Foxit PDF Reader into you Munki repository.</string>
+	<key>Identifier</key>
+	<string>com.github.wycomco.munki.FoxitPDFReader</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Foxit PDF Reader</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>description</key>
+			<string>Industry's most powerful PDF reader. View, annotate, form fill, and sign PDF across desktop, mobile, and web – no matter if you're at the office, home, or on the go.</string>
+			<key>developer</key>
+			<string>Foxit Software Inc.</string>
+			<key>display_name</key>
+			<string>Foxit PDF Reader</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.5</string>
+	<key>ParentRecipe</key>
+	<string>com.github.wycomco.download.FoxitPDFReader</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%found_filename%/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>LSMinimumSystemVersion</key>
+					<string>minimum_os_version</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/%found_basename%</string>
+				</array>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_pkg/payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>minimum_os_version</key>
+					<string>%minimum_os_version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Download and Munki recipes for [Foxit PDF Reader](https://www.foxit.com/pdf-reader/). The download url seems to be static and redirects to the actual pkg download.

Used our common approaches to specify the minimum_os_version and a proper installs array.

Since the version of the downloaded package does not match the version of the installed app, I am overriding the version, as well.