### PR TITLE
Deprecated pragli pesto

### DIFF
--- a/Pragli/Pragli.download.recipe
+++ b/Pragli/Pragli.download.recipe
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)
-Due to dynamic JavaScript encoding of the dmg path, URLTextSearcher cannot be used without further custom processor. This recipe must be updated once the path changes again.</string>
+	<string>Pesto (formerly named Pragli) is discontinued (see https://twitter.com/PestoHQ for more details.)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Pragli, now named Pesto.</string>
 	<key>Identifier</key>
@@ -18,6 +17,15 @@ Due to dynamic JavaScript encoding of the dmg path, URLTextSearcher cannot be us
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe will soon be removed. Please remove it from your list of recipes.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Pragli/Pragli.download.recipe
+++ b/Pragli/Pragli.download.recipe
@@ -23,7 +23,16 @@
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>This recipe will soon be removed. Please remove it from your list of recipes.</string>
+				<string>This recipe is now non-functional and will soon be removed. Please remove it from your list of recipes.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Pragli/Pragli.munki.recipe
+++ b/Pragli/Pragli.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Pragli has been renamed to "Pesto (Pragli)". To allow updates, the internal name remains "Pragli".</string>
+	<string>Pesto (formerly named Pragli) is discontinued (see https://twitter.com/PestoHQ for more details.)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Pragli and imports it into Munki.</string>
 	<key>Identifier</key>


### PR DESCRIPTION
Pesto (formerly named Pragli) is discontinued (see https://twitter.com/PestoHQ for more details.)

A deprecation warning will appear on each autopkg run.