### PR TITLE
pre-commit-config: added isort hook, this updating python scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 # See https://www.elliotjordan.com/posts/pre-commit-02-autopkg/ for more information
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.12.2
+    rev: v1.12.3
     hooks:
       - id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.wycomco.", "--strict", "--"]
       - id: forbid-autopkg-overrides
       - id: forbid-autopkg-trust-info
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=20"]
@@ -27,14 +27,18 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.13.5
+    rev: v2.15.5
     hooks:
       - id: pylint

--- a/SharedProcessors/MunkiAutoStaging.py
+++ b/SharedProcessors/MunkiAutoStaging.py
@@ -18,12 +18,10 @@
 
 from __future__ import absolute_import
 
+import glob
 import os
 import plistlib
-import glob
-
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from distutils.version import StrictVersion
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/MunkiRepoTeamsNotifier.py
+++ b/SharedProcessors/MunkiRepoTeamsNotifier.py
@@ -19,8 +19,8 @@ limitations under the License.
 
 import json
 import subprocess
-
 from time import sleep
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiRepoTeamsNotifier"]


### PR DESCRIPTION
Added [isort](https://github.com/pycqa/isort) repo for sorting and combining imports in python scripts. It is changing files on the fly, but the changes look good to me.

If isort is not desired, please let me know. I will update only the version strings then and dismiss isort and its changes.