### PR TITLE
LibreOfficeLangPack: Changed deprecated TYPE to ARCH

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.munki.recipe
+++ b/LibreOffice/LibreOfficeLangPack.munki.recipe
@@ -18,8 +18,8 @@
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
 		<string>still</string>
-		<key>TYPE</key>
-		<string>mac-x86_64</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>


### PR DESCRIPTION
Adjusted to comply with parent download [recipe](https://github.com/autopkg/hjuutilainen-recipes/blob/master/LibreOffice/LibreOffice.download.recipe) from hjuutilainen.

Vanilla run tested succesfully, also works with override workflow.