### PR TITLE
Archicad26 ARM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: forbid-autopkg-overrides
       - id: forbid-autopkg-trust-info
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=20"]
@@ -27,18 +27,19 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/ambv/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
+        args: ["--profile", "black"]
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.15.5
+    rev: v2.15.9
     hooks:
       - id: pylint

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -48,7 +48,7 @@ def get_fake_recipe():
 
 class JamfMultiUploader(Processor):
     """This processor invokes the given JamfUploader processor multiple times
-    to support multiple Jamf environments at once."""
+    to support multiple Jamf environments in one AutoPkg run."""
 
     def __init__(self, env=None, infile=None, outfile=None):
         super().__init__(env, infile, outfile)

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -129,11 +129,12 @@ class JamfMultiUploader(Processor):
     def update_env(self, custom_config, substituted_vars):
         """Update env with config, preserving original values in variable"""
 
-        if self.verbose:
-            print("Update env with custom config, preserving original values")
-
-        if self.verbose > 2:
-            pprint.pprint({"env before temporary override": self.env})
+        self.output(
+            "Update env with custom config, preserving original values", 1
+        )
+        self.output(
+            pprint.pformat({"env before temporary override": self.env}), 3
+        )
 
         if custom_config:
             for key, value in custom_config.items():
@@ -143,17 +144,16 @@ class JamfMultiUploader(Processor):
                     )
                 self.env[key] = copy.deepcopy(value)
 
-        if self.verbose > 2:
-            pprint.pprint({"env after temporary override": self.env})
+        self.output(
+            pprint.pformat({"env after temporary override": self.env}), 3
+        )
 
     def restore_env(self, custom_config, substituted_vars):
         """Restore env with original values"""
 
-        if self.verbose > 2:
-            pprint.pprint({"env before reset": self.env})
+        self.output(pprint.pformat({"env before reset": self.env}), 3)
 
-        if self.verbose:
-            print("Resetting original values")
+        self.output("Resetting original values", 1)
 
         if custom_config:
             for key in custom_config.keys():
@@ -162,8 +162,7 @@ class JamfMultiUploader(Processor):
                 else:
                     del self.env[key]
 
-        if self.verbose > 2:
-            pprint.pprint({"env after reset": self.env})
+        self.output(pprint.pformat({"env after reset": self.env}), 3)
 
     def get_processor_class(self, processor_name):
         """Get the processor class"""
@@ -198,9 +197,7 @@ class JamfMultiUploader(Processor):
             if key in processor.env:
                 input_dict[key] = processor.env[key]
 
-        if self.verbose > 1:
-            # pretty print any defined input variables
-            pprint.pprint({"Input": input_dict})
+        self.output(pprint.pformat({"Input": input_dict}), 1)
 
         try:
             self.env = processor.process()
@@ -226,9 +223,7 @@ class JamfMultiUploader(Processor):
             if processor.env.get(key):
                 output_dict[key] = self.env[key]
 
-        if self.verbose > 1:
-            # pretty print output variables
-            pprint.pprint({"Output": output_dict})
+        self.output(pprint.pformat({"Output": output_dict}), 2)
 
         if not run_results["Status"]:
             run_results["Status"] = self.get_processor_status(

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -72,13 +72,13 @@ class JamfMultiUploader(Processor):
         "jamf_uploader_processor_parameters": {
             "required": False,
             "description": "Dictionary with parameters for the used processor."
-            " If specific JSS need different parameters, these should be "
+            " If a specific JSS needs different parameters, these should be "
             "grouped in a separate dictionary item, identified by the "
-            "JSS_URL from jamf_server_configs, default parameters should "
-            "then be made available with a 'default' key."
-            "jamf_server_configs as key, or 'default'.",
+            "JSS_URL from jamf_server_configs variable, common parameters "
+            "should then be made available with a 'default' key.",
         },
     }
+
     output_variables = {
         "jamf_multi_uploader_summary_result": {
             "description": "Description of interesting results."
@@ -93,6 +93,7 @@ class JamfMultiUploader(Processor):
         custom_params,
     ):
         """Make sure that we have access to all needed resources."""
+
         processor_class = self.get_processor_class(processor_name)
 
         # Add this processors input and output vars to our internal vars
@@ -149,6 +150,7 @@ class JamfMultiUploader(Processor):
 
         if self.verbose:
             print("Resetting original values")
+
         if custom_config:
             for key in custom_config.keys():
                 if key in substituted_vars:
@@ -174,6 +176,7 @@ class JamfMultiUploader(Processor):
         except (KeyError, AttributeError) as err:
             msg = f"Unknown processor '{processor_name}'."
             raise AutoPackagerError(msg) from err
+
         except AutoPackagerLoadError as err:
             msg = (
                 f"Unable to import '{processor_name}', likely due "
@@ -197,6 +200,7 @@ class JamfMultiUploader(Processor):
 
         try:
             self.env = processor.process()
+
         # Disable broad-except error since we do not know what
         # exception may occur
         except Exception as err:  # pylint: disable=broad-except
@@ -230,6 +234,7 @@ class JamfMultiUploader(Processor):
 
     def prepare_and_run(self, processor_name, custom_config):
         """Temporarly override env and run processor"""
+
         substituted_vars = {}
         run_results = {
             "JSS_URL": "",
@@ -244,7 +249,6 @@ class JamfMultiUploader(Processor):
         # Actually running the given processor, using the code from autopkglib
         processor_class = self.get_processor_class(processor_name)
         processor = processor_class(self.env)
-
         self.execute_processor(processor=processor, run_results=run_results)
 
         self.restore_env(
@@ -295,7 +299,6 @@ class JamfMultiUploader(Processor):
         )
 
         for jamf_server_config in jamf_server_configs:
-
             # Get the JSS URL for this run, to identify special params
             jss_url = jamf_server_config.get("JSS_URL", "")
 
@@ -313,6 +316,7 @@ class JamfMultiUploader(Processor):
 
     def generate_summary_result(self):
         """Generate an autopkg summary result"""
+
         # clear any pre-existing summary result
         if "jamf_multi_uploader_summary_result" in self.env:
             del self.env["jamf_multi_uploader_summary_result"]

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -28,7 +28,6 @@ from autopkglib import (
     AutoPackagerError,
     AutoPackagerLoadError,
     Processor,
-    ProcessorError,
     get_processor,
 )
 
@@ -172,7 +171,9 @@ class JamfMultiUploader(Processor):
 
         try:
             self.env = processor.process()
-        except ProcessorError as err:
+        # Disable broad-except error since we do not know what
+        # exception may occur
+        except Exception as err:  # pylint: disable=broad-except
             if self.verbose > 2:
                 exc_traceback = sys.exc_info()[2]
                 traceback.print_exc(file=sys.stdout)

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -227,10 +227,41 @@ class JamfMultiUploader(Processor):
             pprint.pprint({"Output": output_dict})
 
         if not run_results["Status"]:
-            if "pkg_uploaded" in output_dict and output_dict["pkg_uploaded"]:
-                run_results["Status"] = "Uploaded"
-            else:
-                run_results["Status"] = "Not uploaded"
+            run_results["Status"] = self.get_processor_status(
+                output_dict=output_dict
+            )
+
+    def get_processor_status(self, output_dict):
+        """Returns the relevant part of a processor's output"""
+
+        # Split the name to get the actual processor name
+        processor_name = self.env["jamf_uploader_name"].split("/")[1]
+
+        return {
+            "JamfPackageUploader": "Uploaded"
+            if output_dict.get("pkg_uploaded", False)
+            else "Not Uploaded",
+            "JamfPatchUploader": output_dict.get("patch", "Not Uploaded"),
+            "JamfAccountUploader": output_dict.get(
+                "account_name", "Not Uploaded"
+            ),
+            "JamfCategoryUploader": output_dict.get(
+                "category", "Not Uploaded"
+            ),
+            "JamfDockItemUploader": output_dict.get(
+                "dock_item", "Not Uploaded"
+            ),
+            "JamfIconUploader": output_dict.get("icon_id", "Not Uploaded"),
+            "JamfMacAppUploader": output_dict.get(
+                "macapp_name", "Not Uploaded"
+            ),
+            "JamfPolicyUploader": output_dict.get(
+                "policy_name", "Not Uploaded"
+            ),
+            "JamfScriptUploader": output_dict.get(
+                "script_name", "Not Uploaded"
+            ),
+        }.get(processor_name, "Success")
 
     def prepare_and_run(self, processor_name, custom_config):
         """Temporarly override env and run processor"""
@@ -341,7 +372,9 @@ class JamfMultiUploader(Processor):
             version = "n/a"
 
         self.env["jamf_multi_uploader_summary_result"] = {
-            "summary_text": ("Running JamfUploader processor multiple times:"),
+            "summary_text": (
+                "Running JamfUploader processors multiple times:"
+            ),
             "report_fields": [
                 "Processor",
                 "PKG",

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -1,0 +1,294 @@
+#!/usr/local/autopkg/python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 wycomco GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for JamfMultiUploader class"""
+
+from __future__ import absolute_import
+
+import os
+import pathlib
+import pprint
+import sys
+import traceback
+
+from autopkglib import (
+    AutoPackagerError,
+    AutoPackagerLoadError,
+    Processor,
+    ProcessorError,
+    get_processor,
+)
+
+__all__ = ["JamfMultiUploader"]
+
+
+def get_fake_recipe():
+    """Since get_processor requires a recipe to find any non-standard
+    processors we make a simple fake_recipe to provide a base search path"""
+
+    fake_recipe = {
+        "RECIPE_PATH": pathlib.Path(__file__).parent.resolve(),
+        "PARENT_RECIPES": None,
+    }
+
+    return fake_recipe
+
+
+class JamfMultiUploader(Processor):
+    """This processor invokes the JamfUploader processor multiple times
+    to support multiple Jamf environments at once."""
+
+    def __init__(self, env=None, infile=None, outfile=None):
+        super().__init__(env, infile, outfile)
+        self.verbose = 0
+        self.options = {}
+        self.processor_results = []
+
+    description = __doc__
+    input_variables = {
+        "pkg_path": {
+            "required": True,
+            "description": "Path to a pkg or dmg to import - provided by "
+            "previous pkg recipe/processor.",
+            "default": "",
+        },
+        "jamf_server_configs": {
+            "required": False,
+            "description": "List of dictionaries containing individual configs"
+            "parameters for specific Jamf Pro servers.",
+        },
+    }
+    output_variables = {
+        "jamf_multi_uploader_summary_result": {
+            "description": "Description of interesting results."
+        },
+    }
+
+    def check_dependencies(self, processor_name):
+        """Make sure that we have access to all needed resources."""
+        # Initialize variable set with input variables.
+        variables = set(self.env.keys())
+
+        processor_class = self.get_processor_class(processor_name)
+
+        # Add this processors input and output vars to our internal vars
+        self.input_variables.update(processor_class.input_variables)
+        self.output_variables.update(processor_class.output_variables)
+
+        # Make sure all required input variables exist.
+        for key, flags in list(self.input_variables.items()):
+            if flags["required"] and (key not in variables):
+                raise AutoPackagerError(
+                    f"{processor_name} requires missing argument {key}"
+                )
+
+        # Add output variables to set.
+        variables.update(set(processor_class.output_variables.keys()))
+
+    def update_env(self, custom_config, substituted_vars):
+        """Update env with config, preserving original values in variable"""
+
+        if self.verbose:
+            print("Update env with custom config, preserving original values")
+
+        if self.verbose > 2:
+            pprint.pprint({"env before temporary override": self.env})
+
+        if custom_config:
+            for key, value in custom_config.items():
+                if self.env[key]:
+                    substituted_vars.update({key: self.env[key]})
+                self.env[key] = value
+
+        if self.verbose > 2:
+            pprint.pprint({"env after temporary override": self.env})
+
+    def restore_env(self, custom_config, substituted_vars):
+        """Restore env with original values"""
+
+        if self.verbose > 2:
+            pprint.pprint({"env before reset": self.env})
+
+        if self.verbose:
+            print("Resetting original values")
+        if custom_config:
+            for key in custom_config.keys():
+                if substituted_vars[key]:
+                    self.env[key] = substituted_vars[key]
+                else:
+                    del self.env[key]
+
+        if self.verbose > 2:
+            pprint.pprint({"env after reset": self.env})
+
+    def get_processor_class(self, processor_name):
+        """Get the processor class"""
+
+        fake_recipe = get_fake_recipe()
+
+        try:
+            processor_class = get_processor(
+                processor_name=processor_name,
+                recipe=fake_recipe,
+                verbose=self.verbose,
+                env=self.env,
+            )
+        except (KeyError, AttributeError) as err:
+            msg = f"Unknown processor '{processor_name}'."
+            raise AutoPackagerError(msg) from err
+        except AutoPackagerLoadError as err:
+            msg = (
+                f"Unable to import '{processor_name}', likely due "
+                "to syntax or Python error."
+            )
+            raise AutoPackagerError(msg) from err
+
+        return processor_class
+
+    def execute_processor(self, processor, run_results):
+        """Executes a processor and stores results in var"""
+
+        input_dict = {}
+        for key in list(processor.input_variables.keys()):
+            if key in processor.env:
+                input_dict[key] = processor.env[key]
+
+        if self.verbose > 1:
+            # pretty print any defined input variables
+            pprint.pprint({"Input": input_dict})
+
+        try:
+            self.env = processor.process()
+        except ProcessorError as err:
+            if self.verbose > 2:
+                exc_traceback = sys.exc_info()[2]
+                traceback.print_exc(file=sys.stdout)
+                traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
+
+            print(err, file=sys.stderr)
+            run_results["Status"] = "ERROR"
+            run_results["Message"] += str(err)
+
+        output_dict = {}
+
+        for key in list(processor.output_variables.keys()):
+            # Safety workaround for Processors that may output
+            # differently-named output variables than are given in
+            # their output_variables
+            if processor.env.get(key):
+                output_dict[key] = self.env[key]
+
+        if self.verbose > 1:
+            # pretty print output variables
+            pprint.pprint({"Output": output_dict})
+
+        if not run_results["Status"]:
+            if "pkg_uploaded" in output_dict and output_dict["pkg_uploaded"]:
+                run_results["Status"] = "Uploaded"
+            else:
+                run_results["Status"] = "Not uploaded"
+
+    def prepare_and_run(self, processor_name, custom_config):
+        """Temporarly override env and run processor"""
+        substituted_vars = {}
+        run_results = {
+            "JSS_URL": "",
+            "Status": "",
+            "Message": "",
+        }
+
+        self.update_env(
+            custom_config=custom_config, substituted_vars=substituted_vars
+        )
+
+        # Actually running the given processor, using the code from autopkglib
+        processor_class = self.get_processor_class(processor_name)
+        processor = processor_class(self.env)
+
+        self.execute_processor(processor=processor, run_results=run_results)
+
+        self.restore_env(
+            custom_config=custom_config, substituted_vars=substituted_vars
+        )
+
+        if custom_config["JSS_URL"]:
+            run_results["JSS_URL"] = custom_config["JSS_URL"]
+        else:
+            run_results["JSS_URL"] = "n/a"
+
+        self.processor_results.append(run_results)
+
+        del processor
+        del processor_class
+        del substituted_vars
+
+    def run_processor(self, processor_name):
+        """Run the needed processor"""
+        self.check_dependencies(processor_name=processor_name)
+
+        for jamf_server_config in self.env["jamf_server_configs"]:
+            self.prepare_and_run(
+                processor_name=processor_name, custom_config=jamf_server_config
+            )
+
+    def main(self, options=None):
+
+        if options:
+            self.options = options
+            if self.options.verbose:
+                self.verbose = self.options.verbose
+
+        self.run_processor(
+            processor_name="com.github.grahampugh.jamf-upload.processors"
+            "/JamfPackageUploader"
+        )
+
+        # clear any pre-existing summary result
+        if "jamf_multi_uploader_summary_result" in self.env:
+            del self.env["jamf_multi_uploader_summary_result"]
+
+        server_status = []
+
+        for single_result in self.processor_results:
+            server_status.append(
+                f'{single_result["JSS_URL"]} ({single_result["Status"]})'
+            )
+
+        if "pkg_path" in self.env:
+            pkg_name = os.path.basename(self.env["pkg_path"])
+        else:
+            pkg_name = "n/a"
+
+        self.env["jamf_multi_uploader_summary_result"] = {
+            "summary_text": (
+                "Package upload to one or more Jamf instances was processed:"
+            ),
+            "report_fields": [
+                "PKG Name",
+                "Version",
+                "Jamf Servers (Status)",
+            ],
+            "data": {
+                "PKG Name": pkg_name,
+                "Version": self.env["version"],
+                "Jamf Servers (Status)": ", ".join(server_status),
+            },
+        }
+
+
+if __name__ == "__main__":
+    PROCESSOR = JamfMultiUploader()
+    PROCESSOR.execute_shell()

--- a/archicad_updates/ARCHICADUpdate.download.recipe
+++ b/archicad_updates/ARCHICADUpdate.download.recipe
@@ -5,21 +5,24 @@
 	<key>Description</key>
 	<string>Downloads the latest update build of ARCHICAD based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 
-MAJOR_VERSION options include:  20, 21, 22, 23, and 24
+MAJOR_VERSION options include:  20, 21, 22, 23, 24, 25 and 26
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
-RELEASE_TYPE options include:  AC (for full version), SOLO, and START</string>
+RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
+ARCHITECTURE:  INTEL or ARM, falls back to INTEL</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.download.ARCHICADUpdate</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCHITECTURE</key>
+		<string>INTEL</string>
 		<key>LOCALIZATION</key>
 		<string>INT</string>
 		<key>MAJOR_VERSION</key>
-		<string>23</string>
+		<string>26</string>
 		<key>NAME</key>
 		<string>ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%_update</string>
 		<key>RELEASE_TYPE</key>
-		<string>AC</string>
+		<string>FULL</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -40,7 +43,7 @@ RELEASE_TYPE options include:  AC (for full version), SOLO, and START</string>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%_%ARCHITECTURE%-%version%.dmg</string>
 				<key>url</key>
 				<string>%url%</string>
 			</dict>

--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -6,23 +6,26 @@
 	<string>Imports the latest update build of ARCHICAD into munki which has been downloaded by its parent based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 The installation target can be changed by setting INSTALL_DIR to a different location. Useful e.g. if multiple language versions should be available on a Mac.
 
-MAJOR_VERSION options include:  20, 21, 22, 23, 24, and 25
+MAJOR_VERSION options include:  20, 21, 22, 23, 24, 25 and 26
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
-RELEASE_TYPE options include:  FULL (for full version), SOLO, and START
-MINIMUM_OS_VERSION: AC 20: 10.9, AC 21: 10.10, AC 22: 10.11, AC 23: 10.13, AC 24: 10.13, AC 25: 10.15. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
+RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
+MINIMUM_OS_VERSION: AC 20: 10.9, AC 21: 10.10, AC 22: 10.11, AC 23: 10.13, AC 24: 10.13, AC 25: 10.15, AC 26: 11.3. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
+ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 </string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.ARCHICADUpdate</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCHITECTURE</key>
+		<string>INTEL</string>
 		<key>INSTALL_DIR</key>
 		<string>/Applications/GRAPHISOFT/ARCHICAD %MAJOR_VERSION%</string>
 		<key>LOCALIZATION</key>
 		<string>INT</string>
 		<key>MAJOR_VERSION</key>
-		<string>25</string>
+		<string>26</string>
 		<key>MINIMUM_OS_VERSION</key>
-		<string>10.13</string>
+		<string>11.3</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/graphisoft/ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%</string>
 		<key>NAME</key>
@@ -96,9 +99,9 @@ INSTALLER="/var/tmp/%dmg_found_filename%"
 TARGET_DIR="%INSTALL_DIR%"
 
 if [ -n "$TARGET_DIR" ]; then
-    "$INSTALLER/Contents/MacOS/osx-x86_64" --mode unattended --installdir "$TARGET_DIR"
+    "$INSTALLER/Contents/MacOS/osx-%supported_architecture%" --mode unattended --installdir "$TARGET_DIR"
 else
-    "$INSTALLER/Contents/MacOS/osx-x86_64" --mode unattended
+    "$INSTALLER/Contents/MacOS/osx-%supported_architecture%" --mode unattended
 fi
 rm -rf "$INSTALLER"
 </string>
@@ -108,6 +111,10 @@ rm -rf "$INSTALLER"
 INSTALLER="/var/tmp/%dmg_found_filename%"
 rm -rf "$INSTALLER"
 </string>
+					<key>supported_architectures</key>
+					<array>
+						<string>%supported_architecture%</string>
+					</array>
 					<key>uninstallable</key>
 					<false/>
 					<key>update_for</key>


### PR DESCRIPTION
Support ARM builds by adding an ARCHITECTURE option, which falls back to INTEL. This became urgent, since Graphisoft published an ARM only build with a higher build number than the corresponding Intel build.