### PR TITLE
ARCHICAD: Support for ARM builds

### DIFF
--- a/archicad_updates/ARCHICADUpdate.download.recipe
+++ b/archicad_updates/ARCHICADUpdate.download.recipe
@@ -5,21 +5,24 @@
 	<key>Description</key>
 	<string>Downloads the latest update build of ARCHICAD based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 
-MAJOR_VERSION options include:  20, 21, 22, 23, and 24
+MAJOR_VERSION options include:  20, 21, 22, 23, 24, 25 and 26
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
-RELEASE_TYPE options include:  AC (for full version), SOLO, and START</string>
+RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
+ARCHITECTURE:  INTEL or ARM, falls back to INTEL</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.download.ARCHICADUpdate</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCHITECTURE</key>
+		<string>INTEL</string>
 		<key>LOCALIZATION</key>
 		<string>INT</string>
 		<key>MAJOR_VERSION</key>
-		<string>23</string>
+		<string>26</string>
 		<key>NAME</key>
 		<string>ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%_update</string>
 		<key>RELEASE_TYPE</key>
-		<string>AC</string>
+		<string>FULL</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -40,7 +43,7 @@ RELEASE_TYPE options include:  AC (for full version), SOLO, and START</string>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%_%ARCHITECTURE%-%version%.dmg</string>
 				<key>url</key>
 				<string>%url%</string>
 			</dict>

--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -6,23 +6,26 @@
 	<string>Imports the latest update build of ARCHICAD into munki which has been downloaded by its parent based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 The installation target can be changed by setting INSTALL_DIR to a different location. Useful e.g. if multiple language versions should be available on a Mac.
 
-MAJOR_VERSION options include:  20, 21, 22, 23, 24, and 25
+MAJOR_VERSION options include:  20, 21, 22, 23, 24, 25 and 26
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
-RELEASE_TYPE options include:  FULL (for full version), SOLO, and START
-MINIMUM_OS_VERSION: AC 20: 10.9, AC 21: 10.10, AC 22: 10.11, AC 23: 10.13, AC 24: 10.13, AC 25: 10.15. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
+RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
+MINIMUM_OS_VERSION: AC 20: 10.9, AC 21: 10.10, AC 22: 10.11, AC 23: 10.13, AC 24: 10.13, AC 25: 10.15, AC 26: 11.3. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
+ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 </string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.ARCHICADUpdate</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCHITECTURE</key>
+		<string>INTEL</string>
 		<key>INSTALL_DIR</key>
 		<string>/Applications/GRAPHISOFT/ARCHICAD %MAJOR_VERSION%</string>
 		<key>LOCALIZATION</key>
 		<string>INT</string>
 		<key>MAJOR_VERSION</key>
-		<string>25</string>
+		<string>26</string>
 		<key>MINIMUM_OS_VERSION</key>
-		<string>10.13</string>
+		<string>11.3</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/graphisoft/ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%</string>
 		<key>NAME</key>
@@ -96,9 +99,9 @@ INSTALLER="/var/tmp/%dmg_found_filename%"
 TARGET_DIR="%INSTALL_DIR%"
 
 if [ -n "$TARGET_DIR" ]; then
-    "$INSTALLER/Contents/MacOS/osx-x86_64" --mode unattended --installdir "$TARGET_DIR"
+    "$INSTALLER/Contents/MacOS/osx-%supported_architecture%" --mode unattended --installdir "$TARGET_DIR"
 else
-    "$INSTALLER/Contents/MacOS/osx-x86_64" --mode unattended
+    "$INSTALLER/Contents/MacOS/osx-%supported_architecture%" --mode unattended
 fi
 rm -rf "$INSTALLER"
 </string>
@@ -108,6 +111,10 @@ rm -rf "$INSTALLER"
 INSTALLER="/var/tmp/%dmg_found_filename%"
 rm -rf "$INSTALLER"
 </string>
+					<key>supported_architectures</key>
+					<array>
+						<string>%supported_architecture%</string>
+					</array>
 					<key>uninstallable</key>
 					<false/>
 					<key>update_for</key>


### PR DESCRIPTION
Support ARM builds by adding an ARCHITECTURE option, which falls back to INTEL. This became urgent, since Graphisoft published an ARM only build with a higher build number than the corresponding Intel build.