### PR TITLE
Fix for Archicad download processor

### DIFF
--- a/archicad_updates/ARCHICADUpdatesProcessor.py
+++ b/archicad_updates/ARCHICADUpdatesProcessor.py
@@ -22,6 +22,7 @@ limitations under the License.
 from __future__ import absolute_import, print_function
 
 import json
+import re
 
 # pylint: disable=W0611
 from autopkglib import Processor, ProcessorError, URLGetter  # noqa: F401
@@ -85,34 +86,77 @@ class ARCHICADUpdatesProcessor(URLGetter):
         # Grab the available downloads.
         # Fixed URL (jutonium)
         response = self.download(
-            "https://graphisoft.com/ww/service/downloads/archicad-updates",
-            headers={"Accept": "application/json"},
+            "https://graphisoft.com/de/service-support/downloads"
         )
-        json_data = json.loads(response)
+
+        # Parse the response to get the json data.
+        json_response = re.search(r":categories='(.*)'", response.decode('utf-8')).group(1)
+        json_data = json.loads(json_response)
+
+        # Parse through the available categories for to identify the category id
+        # for updates.
+        slug = None
+        for json_object in json_data:
+            slug = "update"
+
+            if json_object.get("slug") == slug:
+                category_id = json_object.get("id")
+
+        if not slug or not category_id:
+            raise ProcessorError(
+                "Unable to find a url based on the type update."
+            )
+
+        # Parse the response to get the json data.
+        json_response = re.search(r":platforms='(.*)'", response.decode('utf-8')).group(1)
+        json_data = json.loads(json_response)
+
+        # Parse through the available platforms for to identify the platform id
+        # for the requested architecture.
+        slug = None
+        for json_object in json_data:
+            if architecture == "INTEL":
+                slug = "mac-intel-processor"
+            elif architecture == "ARM":
+                slug = "mac-apple-silicon"
+
+            if json_object.get("slug") == slug:
+                platform_id = json_object.get("id")
+
+        if not slug or not platform_id:
+            raise ProcessorError(
+                "Unable to find a url based on the provided architecture."
+            )
+
+        # Parse the response to get the json data.
+        json_response = re.search(r":downloads='(.*)'", response.decode('utf-8')).group(1)
+        json_data = json.loads(json_response)
 
         # Parse through the available downloads for versions that match the
         # requested paramters.
         # Adress potential python runtime errors by checking for the existence
         # of "build". (jutonium)
         for json_object in json_data:
+
+            # Only proceed if json_object is a dict
+            if not isinstance(json_object, dict):
+                continue
+
             if all(
                 (
+                    json_object.get("category") == category_id,
                     json_object.get("version") == major_version,
-                    json_object.get("localization") == localization,
-                    json_object.get("type") == release_type,
+                    json_object.get("locale") == localization,
+                    json_object.get("edition") == release_type,
+                    json_object.get("platform") == int(platform_id),
+                    json_object.get("type") == 'Archicad',
                     json_object.get("build"),
                 )
             ):
                 # Handling of new internal structure (jutonium)
-                mac_link = (
-                    json_object.get("downloadLinks", {})
-                    .get("mac", {})
-                    .get("url")
-                )
-
-                if mac_link and mac_link.endswith(f"-{architecture}.dmg"):
-                    mac_link = "https://dl.graphisoft.com" + mac_link[3:]
-                    available_builds[json_object.get("build")] = mac_link
+                mac_link = json_object.get("data", {}).get("url")
+                print(mac_link)
+                available_builds[str(json_object.get("build"))] = mac_link
 
         # Get the latest version.
         # Avoid unrelated errors and compute propper version (jutonium)


### PR DESCRIPTION
The previously used update feed didn't include the most recent updates anymore. With this release we are parsing the public available website for the needed data.