### PR TITLE
Bitwarden: Initial commit

### DIFF
--- a/Bitwarden/Bitwarden.munki.recipe
+++ b/Bitwarden/Bitwarden.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Bitwarden universal binary disk image and imports it into Munki.
+
+Override NAME and MUNKI_REPO_SUBDIR to your own preferences. Download is performed by using drewdiver's download recipe.</string>
+	<key>Identifier</key>
+	<string>com.github.wycomco.munki.Bitwarden</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Bitwarden</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>description</key>
+			<string>Official app of the open source password manager app Bitwarden. Can be used in conjunction with browser extensions for all major browsers. Can generate strong and unique passwords, store logins, create secure notes, handle passkeys. Some features like TOTP require a paid license or an own server.</string>
+			<key>developer</key>
+			<string>Bitwarden, Inc.</string>
+			<key>display_name</key>
+			<string>%NAME%</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>ParentRecipe</key>
+	<string>com.github.grumpydrew.download.Bitwarden</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
[drewdriver-recipes](https://github.com/autopkg/drewdiver-recipes/tree/master/Bitwarden) only takes care of Jamf workflows.

Tested succesfully:
- Download of app in repo
- minimum_os_version is evaluated