### PR TITLE
BIMcollab: Removed identifier from expected code signature

### DIFF
--- a/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.pkg.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>APPLICATIONS_PATH</key>
-		<string>/Applications</string>
+		<string>Applications</string>
 		<key>NAME</key>
 		<string>BIMcollabZoom</string>
 		<key>PKGPAYLOAD_DIR</key>
@@ -77,7 +77,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%PKGPAYLOAD_DIR%/%RELATIVE_APP_PATH%</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "Kubus.BIMcollab-ZOOM" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y6ZY6GR8Y3)</string>
+				<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y6ZY6GR8Y3)</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
...since included frameworks did not match anymore. It now just checks for the correct developer certificate.