### PR TITLE
Archicad: Move supported_architecture to pkginfo in input var

### DIFF
--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -48,6 +48,10 @@ ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 			<string>GRAPHISOFT</string>
 			<key>installer_type</key>
 			<string>copy_from_dmg</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%supported_architecture%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>
@@ -111,10 +115,6 @@ rm -rf "$INSTALLER"
 INSTALLER="/var/tmp/%dmg_found_filename%"
 rm -rf "$INSTALLER"
 </string>
-					<key>supported_architectures</key>
-					<array>
-						<string>%supported_architecture%</string>
-					</array>
 					<key>uninstallable</key>
 					<false/>
 					<key>update_for</key>


### PR DESCRIPTION
By now we have added the supported_architecture key as part of the additional_pkgsinfo var. But this lead to forcibly limiting the resulting Munki item to this architecture. Moving the key to the input var leaves the Munki admin to choose whether he or she wants to limit the package to an architecture.