### PR TITLE
Libreoffice releases

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.download.recipe
+++ b/LibreOffice/LibreOfficeLangPack.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>still</string>
+		<string>Latest</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/LibreOffice/LibreOfficeLangPack.download.recipe
+++ b/LibreOffice/LibreOfficeLangPack.download.recipe
@@ -3,11 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string></string>
+	<string>Downloads and packages the latest LibreOffice with the given language. Set RELEASE to either 'Latest' or 'Previous' and ARCH to either 'x86_64' or 'aarch64'.
+
+Please assign the appopriate LANGUAGE_CODE. This can be found by going to https://www.libreoffice.org/download/download-libreoffice, selecting "need another language",
+and selecting the language. The LANGUAGE_CODE can be found at the end of the URL after 'lang='</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.download.LibreOfficeLangPack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>LANGUAGE_CODE</key>
 		<string>fr</string>
 		<key>NAME</key>

--- a/LibreOffice/LibreOfficeLangPack.munki.recipe
+++ b/LibreOffice/LibreOfficeLangPack.munki.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>still</string>
+		<string>Latest</string>
 		<key>ARCH</key>
 		<string>x86_64</string>
 		<key>pkginfo</key>

--- a/LibreOffice/LibreOfficeLangPack.munki.recipe
+++ b/LibreOffice/LibreOfficeLangPack.munki.recipe
@@ -3,11 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads and packages the latest LibreOffice with the given language. Imports it into Munki. Set RELEASE to either "fresh" or "still" and ARCH to either "x86_64" for Intel or "aarch64" for ARM.</string>
+	<string>Downloads and packages the latest LibreOffice with the given language. Imports it into Munki. Set RELEASE to either 'Latest' or 'Previous' and ARCH to either 'x86_64' or 'aarch64'.
+
+Please assign the appopriate LANGUAGE_CODE. This can be found by going to https://www.libreoffice.org/download/download-libreoffice, selecting "need another language",
+and selecting the language. The LANGUAGE_CODE can be found at the end of the URL after 'lang='</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.LibreOfficeLangPack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>LANGUAGE_CODE</key>
 		<string>fr</string>
 		<key>MUNKI_CATEGORY</key>
@@ -18,8 +23,6 @@
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
 		<string>Latest</string>
-		<key>ARCH</key>
-		<string>x86_64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
-		<string>still</string>
+		<string>Latest</string>
 		<key>TYPE</key>
 		<string>mac-x86_64</string>
 	</dict>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -3,19 +3,22 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads and packages the latest LibreOffice with the given language. Set RELEASE to either "fresh" or "still" and TYPE to either "mac-x86_64" or "mac-aarch64"</string>
+	<string>Downloads and packages the latest LibreOffice with the given language. Set RELEASE to either 'Latest' or 'Previous' and ARCH to either 'x86_64' or 'aarch64'.
+
+Please assign the appopriate LANGUAGE_CODE. This can be found by going to https://www.libreoffice.org/download/download-libreoffice, selecting "need another language",
+and selecting the language. The LANGUAGE_CODE can be found at the end of the URL after 'lang='</string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.pkg.LibreOfficeLangPack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>LANGUAGE_CODE</key>
 		<string>fr</string>
 		<key>NAME</key>
 		<string>LibreOffice</string>
 		<key>RELEASE</key>
 		<string>Latest</string>
-		<key>TYPE</key>
-		<string>mac-x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.4.1</string>


### PR DESCRIPTION
LibreOffice has changed its naming of 'fresh' and 'still' to 'Latest' and 'Previous'. The changes from @hjuutilainen's recipes have been taken over accordingly.

Instructions on how to obtain the proper language code have been added.