### PR TITLE
Jamf Multi Uploader: Allow disabling of JSS configs

### DIFF
--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -337,6 +337,17 @@ class JamfMultiUploader(Processor):
             temp_server_config.update(copy.deepcopy(default_params))
             temp_server_config.update(copy.deepcopy(jss_params))
 
+            # Check if the processor is disabled
+            disabled = temp_server_config.get("disabled", False)
+
+            if disabled:
+                self.output(
+                    f"Skipping {processor_name} for JSS {jss_url} as it is"
+                    " disabled",
+                    1,
+                )
+                continue
+
             self.prepare_and_run(
                 processor_name=processor_name,
                 custom_config=temp_server_config,


### PR DESCRIPTION
You may now add a "disabled" key to either the `jamf_uploader_processor_parameters` or to a `jamf_server_configs` to skip the process for the given JSS.

Example for a `jamf_uploader_processor_parameters` in a recipe:

```XML
<dict>
    <key>Arguments</key>
    <dict>
        <key>jamf_uploader_name</key>
        <string>com.github.grahampugh.jamf-upload.processors/JamfPatchUploader</string>
        <key>jamf_uploader_processor_parameters</key>
        <dict>
            <key>default</key>
            <dict>
                <key>patch_softwaretitle</key>
                <string>%SOFTWARE_TITLE%</string>
                <key>patch_template</key>
                <string>jamf_patch_template_selfservice_de.xml</string>
                <key>replace_patch</key>
                <false/>
            </dict>
            <key>https://myveryspecialjss.jamfcloud.com</key>
            <dict>
                <key>disabled</key>
                <true/>
            </dict>
        </dict>
    </dict>
    <key>Processor</key>
    <string>com.github.wycomco.SharedProcessors/JamfMultiUploader</string>
</dict>
```