### PR TITLE
Bitwarden: Add static update URL

### DIFF
--- a/Bitwarden/Bitwarden.munki.recipe
+++ b/Bitwarden/Bitwarden.munki.recipe
@@ -32,7 +32,8 @@ Override NAME and MUNKI_REPO_SUBDIR to your own preferences. Download is perform
 			<string>%NAME%</string>
 			<key>postinstall_script</key>
 			<string>#!/bin/zsh
-sed -i '' 's|url: https://artifacts.bitwarden.com/desktop|url: https://artifacts.bitwarden.com/desktop/Bitwarden-2024.6.4-universal-mac.zip|' /Applications/Bitwarden.app/Contents/Resources/app-update.yml
+appversion=$(plutil -extract CFBundleShortVersionString raw -o - /Applications/Bitwarden.app/Contents/Info.plist)
+sed -i '' "s|url: https://artifacts.bitwarden.com/desktop|url: https://artifacts.bitwarden.com/desktop/Bitwarden-${appversion}-universal-mac.zip|" /Applications/Bitwarden.app/Contents/Resources/app-update.yml
 	</string>
 			<key>unattended_install</key>
 			<true/>

--- a/Bitwarden/Bitwarden.munki.recipe
+++ b/Bitwarden/Bitwarden.munki.recipe
@@ -30,6 +30,10 @@ Override NAME and MUNKI_REPO_SUBDIR to your own preferences. Download is perform
 			<string>%NAME%</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/zsh
+sed -i '' 's|url: https://artifacts.bitwarden.com/desktop|url: https://artifacts.bitwarden.com/desktop/Bitwarden-2024.6.4-universal-mac.zip|' /Applications/Bitwarden.app/Contents/Resources/app-update.yml
+	</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>


### PR DESCRIPTION
This prevents Bitwarden from update checking. Could be handled better by using the CFBundleShortVersionString