### PR TITLE
pre-commit-config: Updated revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 # See https://www.elliotjordan.com/posts/pre-commit-02-autopkg/ for more information
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
       - id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.wycomco.", "--strict", "--"]
       - id: forbid-autopkg-overrides
       - id: forbid-autopkg-trust-info
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=20"]
@@ -27,7 +27,7 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/ambv/black
-    rev: 24.1.1
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -40,6 +40,6 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.3
+    rev: v3.2.3
     hooks:
       - id: pylint


### PR DESCRIPTION
Updated accordingly to [homebysix](https://github.com/autopkg/homebysix-recipes/blob/master/.pre-commit-config.yaml). `pre-commit run --all-files` ran fine, showing only known errors. Tested against AutoPkg 2.7.3.