### PR TITLE
Citrix Workspace: added DeprecationWarning

### DIFF
--- a/CitrixWorkspace/CitrixWorkspaceUniversal.munki.recipe
+++ b/CitrixWorkspace/CitrixWorkspaceUniversal.munki.recipe
@@ -70,11 +70,20 @@ done
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.pkg.citrixworkspaceuniversal</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is not working anymore and will soon be removed. Please remove it from your list of recipes. Please switch to io.github.hjuutilainen.download.CitrixWorkspace as parent recipe.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Parent recipes from @rtrouton are no longer available. Also, another munki recipe already exists at [hjuutilainen-recipes](https://github.com/autopkg/hjuutilainen-recipes/blob/master/CitrixReceiver/CitrixWorkspace.munki.recipe) that is fulfilling the same task. Please switch to that parent recipe. This recipe will be removed in the future.