### PR TITLE
Added DeprecationWarning and StopProcessingIf to all recipes

### DIFF
--- a/ClipStudioPaint/ClipStudioPaint.download.recipe
+++ b/ClipStudioPaint/ClipStudioPaint.download.recipe
@@ -12,9 +12,27 @@
 		<string>ClipStudioPaint</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The download URL points to an outdated version and will soon be removed. Please remove it from your list of recipes.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/ClipStudioPaint/ClipStudioPaint.munki.recipe
+++ b/ClipStudioPaint/ClipStudioPaint.munki.recipe
@@ -52,11 +52,29 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.ClipStudioPaint</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The download URL points to an outdated version and will soon be removed. Please remove it from your list of recipes.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/ClipStudioPaint/ClipStudioPaint.pkg.recipe
+++ b/ClipStudioPaint/ClipStudioPaint.pkg.recipe
@@ -18,11 +18,29 @@
 		<string>%NAME%</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.3</string>
+	<string>1.1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.ClipStudioPaint</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The download URL points to an outdated version and will soon be removed. Please remove it from your list of recipes.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The download URL is outdated. Since none of our customers uses this recipe and no other AutoPkg user has complained since at least v2.0.0, we are deprecating these recipes.