### PR TITLE
Fix code signature verification in AirPrint PPD recipe

### DIFF
--- a/airprint-ppd/airprint-ppd.download.recipe
+++ b/airprint-ppd/airprint-ppd.download.recipe
@@ -44,6 +44,12 @@
 				<string>%pathname%</string>
 				<key>strict_verification</key>
 				<true/>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: wycomco GmbH (CD4727XSC2)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR adds the missing code signature verification requirement for AirPrint PPD.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "airprint_ppd.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-02-25 14:13:49 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: wycomco GmbH (CD4727XSC2)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            ED A9 0E 1D 70 63 B5 7A A0 27 26 4D 9D 6D DF E3 72 D4 73 EC 87 B2
CodeSignatureVerifier:            25 98 A2 51 73 00 37 60 21 9F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
```