### PR TITLE
Fix ac download

### DIFF
--- a/archicad_updates/ARCHICADUpdate.download.recipe
+++ b/archicad_updates/ARCHICADUpdate.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the latest update build of ARCHICAD based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 
-MAJOR_VERSION options include:  24, 25 and 26 (GRAPHISOFT supports the current and two previous versions)
+MAJOR_VERSION options include:  24, 25, 26, 27, 28 (GRAPHISOFT actively supports the current and two previous versions)
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
 RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
 ARCHITECTURE:  INTEL or ARM, falls back to INTEL</string>

--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -11,7 +11,6 @@ LOCALIZATION options include:  INT (international english, part of many other li
 RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
 MINIMUM_OS_VERSION: AC 24: 10.13, AC 25: 10.15, AC 26: 11.3, AC 27: 12.6, AC 28: 12.6.7. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
 ARCHITECTURE:  INTEL or ARM, falls back to INTEL
-SUPPORTED_ARCHITECTURES:  x86_64 or arm64, falls back to x86_64
 </string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.ARCHICADUpdate</string>
@@ -33,8 +32,6 @@ SUPPORTED_ARCHITECTURES:  x86_64 or arm64, falls back to x86_64
 		<string>ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%_update_%ARCHITECTURE%</string>
 		<key>RELEASE_TYPE</key>
 		<string>FULL</string>
-		<key>SUPPORTED_ARCHITECTURES</key>
-		<string>x86_64</string>
 		<key>UPDATE_FOR</key>
 		<string>archicad_%MAJOR_VERSION%_%LOCALIZATION%</string>
 		<key>pkginfo</key>
@@ -53,7 +50,7 @@ SUPPORTED_ARCHITECTURES:  x86_64 or arm64, falls back to x86_64
 			<string>copy_from_dmg</string>
 			<key>supported_architectures</key>
 			<array>
-				<string>%SUPPORTED_ARCHITECTURES%</string>
+				<string>%supported_architecture%</string>
 			</array>
 			<key>unattended_install</key>
 			<true/>

--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -6,11 +6,12 @@
 	<string>Imports the latest update build of ARCHICAD into munki which has been downloaded by its parent based on the override-able parameters: MAJOR_VERSION, LOCALIZATION, and RELEASE_TYPE
 The installation target can be changed by setting INSTALL_DIR to a different location. Useful e.g. if multiple language versions should be available on a Mac.
 
-MAJOR_VERSION options include:  24, 25 and 26 (GRAPHISOFT supports the current and two previous versions)
+MAJOR_VERSION options include:  24, 25, 26, 27, 28 (GRAPHISOFT actively supports the current and two previous versions)
 LOCALIZATION options include:  INT (international english, part of many other licenses), AUS, AUT, BRA, CHE, CHI, CZE, FIN, FRA, GER, GRE, HUN, ITA, JPN, KOR, NED, NOR, NZE, POL, POR, RUS, SPA, SWE, TAI, TUR, UKI, UKR, and USA
 RELEASE_TYPE options include:  FULL (for full version), AC (full versions for older majors), SOLO, and START
-MINIMUM_OS_VERSION: AC 24: 10.13, AC 25: 10.15, AC 26: 11.3. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
+MINIMUM_OS_VERSION: AC 24: 10.13, AC 25: 10.15, AC 26: 11.3, AC 27: 12.6, AC 28: 12.6.7. These are the absolute minimum versions as stated by GRAPHISOFT. Some are listed as "untested but should run".
 ARCHITECTURE:  INTEL or ARM, falls back to INTEL
+SUPPORTED_ARCHITECTURES:  x86_64 or arm64, falls back to x86_64
 </string>
 	<key>Identifier</key>
 	<string>com.github.wycomco.munki.ARCHICADUpdate</string>
@@ -32,6 +33,8 @@ ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 		<string>ARCHICAD%MAJOR_VERSION%_%LOCALIZATION%_update_%ARCHITECTURE%</string>
 		<key>RELEASE_TYPE</key>
 		<string>FULL</string>
+		<key>SUPPORTED_ARCHITECTURES</key>
+		<string>x86_64</string>
 		<key>UPDATE_FOR</key>
 		<string>archicad_%MAJOR_VERSION%_%LOCALIZATION%</string>
 		<key>pkginfo</key>
@@ -50,7 +53,7 @@ ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 			<string>copy_from_dmg</string>
 			<key>supported_architectures</key>
 			<array>
-				<string>%supported_architecture%</string>
+				<string>%SUPPORTED_ARCHITECTURES%</string>
 			</array>
 			<key>unattended_install</key>
 			<true/>

--- a/archicad_updates/ARCHICADUpdatesProcessor.py
+++ b/archicad_updates/ARCHICADUpdatesProcessor.py
@@ -85,7 +85,7 @@ class ARCHICADUpdatesProcessor(URLGetter):
 
         # Grab the available public downloads page
         response = self.download(
-            "https://graphisoft.com/de/service-support/downloads"
+            "https://graphisoft.com/de/service-support/downloads?section=update"
         )
 
         # Parse the html to retrieve the actual json data for the categories.
@@ -97,6 +97,7 @@ class ARCHICADUpdatesProcessor(URLGetter):
         # Parse through the available categories to identify the category id
         # for updates.
         slug = None
+        category_id = None
         for json_object in json_data:
             slug = "update"
 
@@ -117,6 +118,7 @@ class ARCHICADUpdatesProcessor(URLGetter):
         # Parse through the available platforms to identify the platform id
         # for the requested architecture.
         slug = None
+        platform_id = None
         for json_object in json_data:
             if architecture == "INTEL":
                 slug = "mac-intel-processor"


### PR DESCRIPTION
`supported_architecture` was not specified in the munki.recipe, this was fixed by adding a new variable.

When doing a manual `curl` on `https://graphisoft.com/de/service-support/downloads`, no current updates can be found for at least the INT and GER versions. The updates are shown on the website when navigating to "Updates" and the respective language and version, though.

Output of `autopkg run -vvq ARCHICADUpdate.download.recipe`:

```
Processing ARCHICADUpdate.download.recipe...
WARNING: ARCHICADUpdate.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
ARCHICADUpdatesProcessor
{'Input': {'ARCHITECTURE': 'INTEL',
           'localization': 'INT',
           'major_version': '26',
           'release_type': 'FULL'}}
Unable to find a url based on the parameters provided.
Failed.
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.wycomco.download.ARCHICADUpdate/receipts/ARCHICADUpdate.download-receipt-20250310-144156.plist

The following recipes failed:
    ARCHICADUpdate.download.recipe
        Error in com.github.wycomco.download.ARCHICADUpdate: Processor: ARCHICADUpdatesProcessor: Error: Unable to find a url based on the parameters provided.

Nothing downloaded, packaged or imported.
```

Searching for a current release found on the website (e.g., ARCHICAD 28.1.0 build 4000) fails with both version and build string within the output of curl.