### PR TITLE
Archicad: move %supported_architecture% key into processor

### DIFF
--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -48,10 +48,6 @@ ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 			<string>GRAPHISOFT</string>
 			<key>installer_type</key>
 			<string>copy_from_dmg</string>
-			<key>supported_architectures</key>
-			<array>
-				<string>%supported_architecture%</string>
-			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>
@@ -115,6 +111,10 @@ rm -rf "$INSTALLER"
 INSTALLER="/var/tmp/%dmg_found_filename%"
 rm -rf "$INSTALLER"
 </string>
+					<key>supported_architectures</key>
+					<array>
+						<string>%supported_architecture%</string>
+					</array>
 					<key>uninstallable</key>
 					<false/>
 					<key>update_for</key>


### PR DESCRIPTION
The output variable `%supported_architecture%` of the ARCHICADUpdatesProcessor was not evaluated in the `pkginfo` dict. Moving the key and array into the `MunkiPkginfoMerger` processor leads to the variable being set correctly in the resulting plists.

This eliminates the need to hard-code the appropriate architecture (arm64 or x86_64) into an override.