### PR TITLE
Updated pre-commit config, fixed proposals to processors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://www.elliotjordan.com/posts/pre-commit-02-autopkg/ for more information
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.17.0
+    rev: v1.18.0
     hooks:
       - id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.wycomco.", "--strict", "--"]
@@ -21,12 +21,11 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
-      - id: fix-encoding-pragma
       - id: mixed-line-ending
       - id: no-commit-to-branch
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
       - id: black
@@ -38,8 +37,12 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        args: ["--profile", "black"]
   - repo: https://github.com/PyCQA/pylint
     rev: v3.3.3
     hooks:
       - id: pylint
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py38-plus"]

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -1,5 +1,4 @@
 #!/usr/local/autopkg/python
-# -*- coding: utf-8 -*-
 #
 # Copyright 2023 wycomco GmbH
 #
@@ -16,7 +15,6 @@
 # limitations under the License.
 """See docstring for JamfMultiUploader class"""
 
-from __future__ import absolute_import
 
 import copy
 import os
@@ -25,12 +23,8 @@ import pprint
 import sys
 import traceback
 
-from autopkglib import (
-    AutoPackagerError,
-    AutoPackagerLoadError,
-    Processor,
-    get_processor,
-)
+from autopkglib import (AutoPackagerError, AutoPackagerLoadError, Processor,
+                        get_processor)
 
 __all__ = ["JamfMultiUploader"]
 

--- a/SharedProcessors/MunkiAutoStaging.py
+++ b/SharedProcessors/MunkiAutoStaging.py
@@ -1,5 +1,4 @@
 #!/usr/local/autopkg/python
-# -*- coding: utf-8 -*-
 #
 # Copyright 2022 wycomco GmbH
 #
@@ -16,7 +15,6 @@
 # limitations under the License.
 """See docstring for MunkiAutoStaging class"""
 
-from __future__ import absolute_import
 
 import glob
 import os

--- a/SharedProcessors/MunkiRepoTeamsNotifier.py
+++ b/SharedProcessors/MunkiRepoTeamsNotifier.py
@@ -1,5 +1,4 @@
 #!/usr/local/autopkg/python
-# -*- coding: utf-8 -*-
 
 """
 Copyright 2022 bock@wycomco.de
@@ -107,7 +106,7 @@ class MunkiRepoTeamsNotifier(URLGetter):
                 universal_newlines=True,
             ) as proc:
                 (out, err) = proc.communicate()
-        except (IOError, OSError) as error:
+        except OSError as error:
             raise ProcessorError(error) from error
         if proc.returncode != 0 or err:
             self.output(

--- a/archicad_updates/ARCHICADUpdatesProcessor.py
+++ b/archicad_updates/ARCHICADUpdatesProcessor.py
@@ -1,5 +1,4 @@
 #!/usr/local/autopkg/python
-# -*- coding: utf-8 -*-
 
 """
 Copyright 2019 Zack T (mlbz521)
@@ -19,7 +18,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import, print_function
 
 import json
 import re
@@ -85,7 +83,8 @@ class ARCHICADUpdatesProcessor(URLGetter):
 
         # Grab the available public downloads page
         response = self.download(
-            "https://graphisoft.com/de/service-support/downloads?section=update"
+            "https://graphisoft.com/de/service-support/"
+            "downloads?section=update"
         )
 
         # Parse the html to retrieve the actual json data for the categories.


### PR DESCRIPTION
`pyupgrade` was added to the pre-commit repos. It is added to ensure compatibility with version 3.8 at the moment, as done by homebysix.

Several fixes have been done to processors:
- remove unneeded encoding, absolute_import lines and IOError (defaults or removed in python3)
- formatting issues

One thing to consider: In `MunkiAutoStaging.py`, the module `distutils.version` is used. This is deprecated in Python 3.10 (current version of `/usr/local/autopkg/python` and will be removed in Python 3.12. Replacement of this module has not been done, since the pull requester is not as good in python as the reviewer is.