### PR TITLE
Keep pkg in %RECIPE_CACHE_DIR%

### DIFF
--- a/MicrosoftOffice365/Microsoft_Teams2.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_Teams2.pkg.recipe
@@ -114,7 +114,6 @@
 				<array>
 					<string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
 					<string>%RECIPE_CACHE_DIR%/downloads/payload</string>
-					<string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%-%version%.pkg</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
Munki does not need the pkg. Jamf needs it, so we must not remove it in `PathDeleter`.