### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -100,8 +100,6 @@ and selecting the language. The LANGUAGE_CODE can be found at the end of the URL
 					</array>
 					<key>id</key>
 					<string>org.libreoffice.langpack-%LANGUAGE_CODE%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 				</dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._