### PR TITLE
Update FileZilla Unarchiver Actions

### DIFF
--- a/FileZilla/FileZilla.munki.recipe
+++ b/FileZilla/FileZilla.munki.recipe
@@ -94,9 +94,9 @@ For the processor used by this recipe to work you need to import the cryptograph
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%ARCH%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/FileZilla.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/FileZilla.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>

--- a/FileZilla/Filezilla.download.recipe
+++ b/FileZilla/Filezilla.download.recipe
@@ -63,7 +63,9 @@ For the processor used by this recipe to work you need to import the cryptograph
 				<key>archive_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/FileZilla_%version%_macos-%ARCH%.app.tar.bz2</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
@@ -72,7 +74,7 @@ For the processor used by this recipe to work you need to import the cryptograph
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/FileZilla.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/FileZilla.app</string>
 				<key>requirement</key>
 				<string>identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"</string>
 			</dict>


### PR DESCRIPTION
Fixes code signature verification failures due to a new version being copied atop the previous version and cruft files remaining. Also adds an ARCH to the name of the resulting DMG created before import.