### PR TITLE
Keka: Initial commit of Munki parent recipe

### DIFF
--- a/Keka/Keka.munki.recipe
+++ b/Keka/Keka.munki.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Description</key>
+        <string>Downloads the latest Keka version from GitHub and imports into Munki.</string>
+        <key>Identifier</key>
+        <string>com.github.wycomco.munki.Keka</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Keka</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>description</key>
+			<string>Keka is a free file archiving programme for macOS that can optionally encrypt archives. It can create many formats and reads even more, including exotic ones.</string>
+			<key>developer</key>
+			<string>aOne</string>
+			<key>display_name</key>
+			<string>Keka</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>ParentRecipe</key>
+	<string>com.github.hansen-m.download.Keka</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Due to the deprecation of all gerardkok-recipes, the [munki recipe](https://github.com/autopkg/gerardkok-recipes/blob/master/Keka/Keka.munki.recipe) will be retired on July, 19. There exists no other Munki recipe in the official autopkg repos.

The download has changed with a new parent ([hansen-m-recipes](https://github.com/autopkg/hansen-m-recipes/blob/master/Keka/Keka.download.recipe) from https://d.keka.io to the [GitHub releases page](https://github.com/aonez/Keka). The resulting download item is same in size and hash value.