### PR TITLE
Update hook order and arg in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,6 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
-    hooks:
-      - id: black
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:
@@ -37,6 +33,7 @@ repos:
     rev: 9.0.0a3
     hooks:
       - id: isort
+        args: ["--profile", "black"]
   - repo: https://github.com/pycqa/pylint
     rev: v4.0.5
     hooks:
@@ -51,3 +48,7 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.3.1
+    hooks:
+      - id: black

--- a/SharedProcessors/JamfMultiUploader.py
+++ b/SharedProcessors/JamfMultiUploader.py
@@ -22,8 +22,12 @@ import pprint
 import sys
 import traceback
 
-from autopkglib import (AutoPackagerError, AutoPackagerLoadError, Processor,
-                        get_processor)
+from autopkglib import (
+    AutoPackagerError,
+    AutoPackagerLoadError,
+    Processor,
+    get_processor,
+)
 
 __all__ = ["JamfMultiUploader"]
 


### PR DESCRIPTION
There existed a race condition between the `black` and `isort` hooks.

This was resolved by telling `isort` to use the `black` flavor and to place the `black` hook at the end of the config.