### PR TITLE
Update MinimumVersion key for used processors

### DIFF
--- a/EposConnect/EposConnect.munki.recipe
+++ b/EposConnect/EposConnect.munki.recipe
@@ -54,7 +54,7 @@ done
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.EposConnect</string>
 	<key>Process</key>

--- a/Foxit/FoxitPDFReader.munki.recipe
+++ b/Foxit/FoxitPDFReader.munki.recipe
@@ -48,7 +48,7 @@ exit 0</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.FoxitPDFReader</string>
 	<key>Process</key>

--- a/GoToMeetingScheduler/GoToMeetingScheduler.download.recipe
+++ b/GoToMeetingScheduler/GoToMeetingScheduler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://jm-cdn.azureedge.net/g2m-scheduler-for-mac/G2MAppcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GoToMeetingScheduler/GoToMeetingScheduler.munki.recipe
+++ b/GoToMeetingScheduler/GoToMeetingScheduler.munki.recipe
@@ -45,7 +45,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.GoToMeetingScheduler</string>
 	<key>Process</key>

--- a/LibreOffice/LibreOfficeLangPack.download.recipe
+++ b/LibreOffice/LibreOfficeLangPack.download.recipe
@@ -21,7 +21,7 @@ and selecting the language. The LANGUAGE_CODE can be found at the end of the URL
 		<string>Latest</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
 	<key>Process</key>

--- a/LibreOffice/LibreOfficeLangPack.munki.recipe
+++ b/LibreOffice/LibreOfficeLangPack.munki.recipe
@@ -50,7 +50,7 @@ and selecting the language. The LANGUAGE_CODE can be found at the end of the URL
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.LibreOfficeLangPack</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Excel_365.munki.recipe
+++ b/MicrosoftOffice365/Microsoft_Excel_365.munki.recipe
@@ -68,7 +68,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.microsoftexcel365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Excel_365.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_Excel_365.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftexcel365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_OneNote_365.munki.recipe
+++ b/MicrosoftOffice365/Microsoft_OneNote_365.munki.recipe
@@ -39,7 +39,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.microsoftonenote365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_OneNote_365.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_OneNote_365.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftonenote365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Outlook_365.munki.recipe
+++ b/MicrosoftOffice365/Microsoft_Outlook_365.munki.recipe
@@ -68,7 +68,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.microsoftoutlook365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Outlook_365.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_Outlook_365.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftoutlook365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_PowerPoint_365.munki.recipe
+++ b/MicrosoftOffice365/Microsoft_PowerPoint_365.munki.recipe
@@ -68,7 +68,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.microsoftpowerpoint365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_PowerPoint_365.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_PowerPoint_365.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftpowerpoint365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Teams2.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_Teams2.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftteams</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Word_365.munki.recipe
+++ b/MicrosoftOffice365/Microsoft_Word_365.munki.recipe
@@ -68,7 +68,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.microsoftword365</string>
 	<key>Process</key>

--- a/MicrosoftOffice365/Microsoft_Word_365.pkg.recipe
+++ b/MicrosoftOffice365/Microsoft_Word_365.pkg.recipe
@@ -20,7 +20,7 @@
 		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftword365</string>
 	<key>Process</key>

--- a/PDFStudio/PDF_Studio.munki.recipe
+++ b/PDFStudio/PDF_Studio.munki.recipe
@@ -41,7 +41,7 @@ This recipe requires com.github.jazzace.processors/TextSearcher to identify the 
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>2.3</string>
+	<string>2.6</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.PDFStudio</string>
 	<key>Process</key>

--- a/Unclack/Unclack.dmg.recipe
+++ b/Unclack/Unclack.dmg.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.Unclack</string>
 	<key>Process</key>

--- a/Unclack/Unclack.munki.recipe
+++ b/Unclack/Unclack.munki.recipe
@@ -36,7 +36,7 @@ After launching Unclack for the first time, you need to follow the steps describ
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.dmg.Unclack</string>
 	<key>Process</key>

--- a/WindowsApp/Windows_App.munki.recipe
+++ b/WindowsApp/Windows_App.munki.recipe
@@ -60,7 +60,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.pkg.windowsapp</string>
 	<key>Process</key>

--- a/WindowsApp/Windows_App.pkg.recipe
+++ b/WindowsApp/Windows_App.pkg.recipe
@@ -22,7 +22,7 @@
 		<string>CFBundleShortVersionString</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.microsoftwindowsapp</string>
 	<key>Process</key>

--- a/airprint-ppd/airprint-ppd.download.recipe
+++ b/airprint-ppd/airprint-ppd.download.recipe
@@ -12,7 +12,7 @@
 		<string>airprint_ppd</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/airprint-ppd/airprint-ppd.munki.recipe
+++ b/airprint-ppd/airprint-ppd.munki.recipe
@@ -37,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.airprint-ppd</string>
 	<key>Process</key>

--- a/archicad_updates/ARCHICADUpdate.munki.recipe
+++ b/archicad_updates/ARCHICADUpdate.munki.recipe
@@ -55,7 +55,7 @@ ARCHITECTURE:  INTEL or ARM, falls back to INTEL
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.wycomco.download.ARCHICADUpdate</string>
 	<key>Process</key>

--- a/bimcollab_zoom/BIMcollabZOOM.download.recipe
+++ b/bimcollab_zoom/BIMcollabZOOM.download.recipe
@@ -20,7 +20,7 @@
 		<string>%APPLICATIONS_PATH%/BIMcollab ZOOM/BIMcollab ZOOM.app</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/sipgate_softphone/sipgate-softphone.download.recipe
+++ b/sipgate_softphone/sipgate-softphone.download.recipe
@@ -12,7 +12,7 @@
 		<string>sipgate-softphone</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Thanks to @homebysix's `pre-commit-macadmin` repo, the MinimumVersion keys were updated to reflect the processor with the highest AutoPkg version needed.